### PR TITLE
Prevent overly greedy empty object elimination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- [Bug] Prevent overly greedy empty object elimination
+
 ## 0.5.0
 
 - Assign errors via an `assign_errors` helper ([#10](https://github.com/inertiajs/inertia-phoenix/issues/10))

--- a/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
+++ b/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
@@ -26,7 +26,7 @@ defmodule MyAppWeb.PageController do
   def nested(conn, _params) do
     conn
     |> assign(:page_title, "Home")
-    |> assign_prop(:a, %{b: %{c: "c", d: "d", e: %{f: "f", g: "g"}}})
+    |> assign_prop(:a, %{b: %{c: "c", d: "d", e: %{f: "f", g: "g", h: %{}}}})
     |> render_inertia("Home")
   end
 


### PR DESCRIPTION
We were eliminating empty objects too aggressively from props (in the logic where we resolve partial reload rules).