### PR TITLE
Update mix.exs by updating ex_doc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -41,7 +41,7 @@ defmodule Inertia.MixProject do
       {:plug_cowboy, "~> 2.1", only: :test},
       {:floki, ">= 0.30.0", only: :test},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.27", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:nodejs, "~> 3.0"},
       {:ecto, ">= 3.0.0"}


### PR DESCRIPTION
The current version of `ex_doc` is an old one. So the docs on hexdocs don't have the new documentation with a light sidebar in light mode, the new font, and the somewhat new UI. By updating to version `0.34` newest version will be used.