### PR TITLE
Check for external redirect before converting status to 303

### DIFF
--- a/lib/inertia/plug.ex
+++ b/lib/inertia/plug.ex
@@ -101,10 +101,6 @@ defmodule Inertia.Plug do
   defp convert_redirects(conn) do
     register_before_send(conn, fn %{method: method, status: status} = conn ->
       cond do
-        # see: https://inertiajs.com/redirects#303-response-code
-        method in ["PUT", "PATCH", "DELETE"] and status in [301, 302] ->
-          put_status(conn, 303)
-
         # see: https://inertiajs.com/redirects#external-redirects
         external_redirect?(conn) ->
           [location] = get_resp_header(conn, "location")
@@ -112,6 +108,10 @@ defmodule Inertia.Plug do
           conn
           |> put_status(409)
           |> put_resp_header("x-inertia-location", location)
+
+        # see: https://inertiajs.com/redirects#303-response-code
+        method in ["PUT", "PATCH", "DELETE"] and status in [301, 302] ->
+          put_status(conn, 303)
 
         true ->
           conn


### PR DESCRIPTION
## Issue
After performing a `PUT`, `PATCH`, or `DELETE` request, you may want to do an external redirect.

Currently, this is not possible because the plug contains a `cond` block that first checks for `PUT`/`PATCH`/`DELETE` requests and converts them into `303` responses. As a result, the second condition, which checks for external redirects, is never executed for these requests.

## Proposed change
Reorder the conditions in the `cond` block so that the check for external redirects occurs before the `303` response conversion. This way, external redirects will be always be converted to `409` responses.

Hopefully, I didn’t miss any reason why we may not want to allow external redirects after performing `PUT`/`PATCH`/`DELETE` requests!