### PR TITLE
Update README.md to give example on how to update Dockerfile to install nodejs

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,7 +694,25 @@ Then, update your Inertia Elixir configuration to enable SSR.
     # CSR).
     raise_on_ssr_failure: config_env() != :prod
 ```
+If you haven't installed node into your runner image add the following command after the `FROM ${RUNNER_IMAGE}`
+```diff
+FROM ${RUNNER_IMAGE}
 
+RUN apt-get update -y && \
+-     apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates && \
++     apt-get install -y libstdc++6 openssl curl libncurses5 locales ca-certificates && \ # add curl to dependencies
+      apt-get clean && rm -f /var/lib/apt/lists/*_*
+
+# Install Node JS from https://deb.nodesource.com/
++ RUN curl -fsSL https://deb.nodesource.com/setup_x.x | bash - && \
++    apt-get update && \
++    apt-get install -y nodejs
+
+# ...
+
+ENV MIX_ENV="prod"
++ ENV NODE_ENV="production"
+```
 In production, be sure to set `NODE_ENV` environment variable to `production`, so that the SSR script is cached for optimal performance.
 
 ### Client side hydration


### PR DESCRIPTION
By default, phoenix apps use Debian, so I thought I'd add documentation on how to install this since I've been hitting a snag around the following error. I thought I already had node installed, but I didn't realize it was in my builder image. 

Anyways, I hope this is a nice addition to help people get onboarded

```
 ** (MatchError) no match of right hand side value: {:error, {:enoent, [{:erlang, :open_port, [{:spawn_executable, nil}, [line: 65536, env: [{~c"NODE_PATH", ~c"/app/lib/climate_collective-0.2.0/priv:/app/lib/app-0.2.0/priv/node_modules"}, {~c"WRITE_CHUNK_SIZE", ~c"65536"}], args: ["/app/lib/nodejs-3.1.0/priv/server.js"]]], [error_info: %{module: :erl_erts_errors}]}, {NodeJS.Worker, :init, 1, [file: ~c"lib/nodejs/worker.ex", line: 51]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 2057]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 2012]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 329]}]}}
```