### PR TITLE
feat: Add `inertia_deep_merge` method for handling complex data merges in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,13 @@ conn
 |> assign_prop(:paginated_list, inertia_defer(&calculate_next_page/0) |> inertia_merge())
 ```
 
+If you are working with complex data structures or nested objects you can use `inertia_deep_merge(value)`
+
+```elixir
+conn
+|> assign_prop(:complex_object, inertia_deep_merge(%{a: %{b: %{c: %{d: 1}}}}))
+```
+
 ## Shared data
 
 To share data on every request, you can use the `assign_prop/2` function inside of a shared plug in your response pipeline. For example, suppose you have a `UserAuth` plug responsible for fetching the currently-logged in user and you want to be sure all your Inertia components receive that user data. Your plug might look something like this:

--- a/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
+++ b/test/support/my_app/lib/my_app_web/controllers/page_controller.ex
@@ -111,6 +111,16 @@ defmodule MyAppWeb.PageController do
     |> render_inertia("Home")
   end
 
+  def deep_merge_props(conn, _params) do
+    conn
+    |> assign(:page_title, "Home")
+    |> assign_prop(:a, inertia_deep_merge(%{a: %{b: %{c: 1}}}))
+    |> assign_prop(:b, inertia_deep_merge([:a, :b]))
+    |> assign_prop(:c, inertia_merge("c"))
+    |> assign_prop(:d, "d")
+    |> render_inertia("Home")
+  end
+
   def deferred_props(conn, _params) do
     conn
     |> assign(:page_title, "Home")

--- a/test/support/my_app/lib/my_app_web/router.ex
+++ b/test/support/my_app/lib/my_app_web/router.ex
@@ -29,6 +29,7 @@ defmodule MyAppWeb.Router do
     get "/struct_props", PageController, :struct_props
     get "/binary_props", PageController, :binary_props
     get "/merge_props", PageController, :merge_props
+    get "/deep_merge_props", PageController, :deep_merge_props
     get "/deferred_props", PageController, :deferred_props
     get "/encrypted_history", PageController, :encrypted_history
     get "/cleared_history", PageController, :cleared_history


### PR DESCRIPTION
## Description

This PR adds support for the recently addition of "deep prop merging" in Inertia (https://github.com/inertiajs/inertia/pull/2069) into the `phoenix-inertia` package.

This follows the same specification as one can see in the [Inertiajs docs for `merge`](https://inertiajs.com/merging-props):

> Use merge when merging simple arrays, and deepMerge when working with nested objects that contain arrays or complex structures, such as pagination objects.

## Approach
- **New function:** adds `inertia_deep_merge` to `Inertia.Controller`. This method will mark the prop with `{:deep_merge, prop}`
- **Deep prop merge resolution:** In order to not overcomplicate things, the `resolve_merge_props` function has been modified to account for the new `:deep_merge` tag and extract the prop keys in a similar way as the lib was doing with the `merge_props`

## Usage
```elixir
conn
|> assign_prop(:simple, 1)
|> assign_prop(:complex, inertia_deep_merge(%{a: %{b: %{c: 1}}})
```

## Why?
Sometimes when dealing with complex pages, that have intricate objects or datasets, it's often better and necessary to just update the parts of the object that changes instead of the entire object.
For example, suppose we want to append items to the `data` array in a pagination object but leave  `meta` and `links` intact or just partially updated:
```elixir
%{
  items: %{
    data: [...], // Appending new data
    meta: [...], // This remains the same
    links: [...], // Links only updated as needed
  }
}
```